### PR TITLE
change exportToJson fileName format

### DIFF
--- a/auditexport/utils.py
+++ b/auditexport/utils.py
@@ -98,7 +98,7 @@ def saveNextPageStartKey(nextPageStartKey):
 def exportToJson(pathToFolder, records):
     logger.debug('exporting records to json.....')
 
-    fileName = str(datetime.datetime.utcnow().isoformat()) + ".json"
+    fileName = str(datetime.datetime.utcnow().isoformat()).replace(":","_") + ".json"
     fn = os.path.join(pathToFolder, fileName)
     with open(fn, "w") as f:
         json.dump(records, f, sort_keys=True,


### PR DESCRIPTION
As listed the fileName in the exportToJson function uses datetime isoformat() to name the file after the current date and time.  Windows can't accept colons as part of a filename and in turn this errors out.  I recommend replacing the colons with underscores - 
fileName = str(datetime.datetime.utcnow().isoformat()).replace(":","_") + ".json"

I also considered reformatting to not include the full timestamp as part of the filename (date and hour only) but since the API uses pagination, multiple files can be created per request and will end up with the same name, each one overwriting the previous file.  Reformatting the filename to remove colons from the timestamp seems like the easiest fix.  

### Proposed Changes

Windows can't accept colons as part of a filename and fails when trying to name the file with default isoformat() date and time format.  I recommend replacing the colons with underscores - 

"fileName = str(datetime.datetime.utcnow().isoformat()).replace(":","_") + ".json""

Example filename before - 2021-04-06T11:10:04.409.json

Example filename after the change - 2021-04-06T11_10_04.409.json

For reference see the reserved characters in the following Microsoft documentation - 

https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions

### Checklist

*Place an `x` inside the brackets to check off items.*

- [ ] I have [updated the change log](https://github.com/virtru/dev-guide/blob/master/process/merge-and-tag.md#change-log) -No
- [ ] I have updated the `VERSION` file if merging to `master` - N/A
- [ ] I have added tests to cover any new functionality or bugfixes - N/A
